### PR TITLE
Fix dependabot auto-merge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
-        uses: dependabot/fetch-metadata@v1.3.1
+        uses: dependabot/fetch-metadata@v1.6.0
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:


### PR DESCRIPTION
## :question: What is changing?

Update dependabot auto merge github actions.

## :zap: Why this change?

`dependabot/fetch-metadata` was outdated.

[Issue](https://github.com/HanaPoulpe/hanaburtinnetcore/issues/27)

## :sparkles: Change type:

* [ ] Bug fix
* [ ] New feature
* [ ] Refactor
* [ ] Quality of life
* [ ] Documentation
* [X] Version bump

## :pencil2: Check list before merging

* [ ] Relevant tests have been added
* [ ] Relevant documentation have been added
