### PR TITLE
Add localdev settings

### DIFF
--- a/src/localdev/settings/__init__.py
+++ b/src/localdev/settings/__init__.py
@@ -1,0 +1,4 @@
+__all__ = ["Backoffice", "Base"]
+
+from ._base import Base
+from ._interfaces import Backoffice

--- a/src/localdev/settings/_base.py
+++ b/src/localdev/settings/_base.py
@@ -1,0 +1,5 @@
+from queenbees import settings
+
+
+class Base(settings.Base):
+    DEBUG = True

--- a/src/localdev/settings/_interfaces.py
+++ b/src/localdev/settings/_interfaces.py
@@ -1,0 +1,7 @@
+from queenbees import settings
+
+from . import _base as base
+
+
+class Backoffice(base.Base, settings.Backoffice):
+    pass


### PR DESCRIPTION
## :question: What is changing?

Add settings for local development.

## :zap: Why this change?

By running locally using `DJANGO_SETTINGS_MODULE=localdev.settings` we have access to settings make life easier on local dev, nothing much ATM but it will enable the use of local stubber, enforce using the tests endpoints, etc....

## :sparkles: Change type:

* [ ] Bug fix
* [X] New feature
* [ ] Refactor
* [X] Quality of life
* [ ] Documentation

## :pencil2: Check list before merging

* [ ] Relevant tests have been added
* [ ] Relevant documentation have been added
