### PR TITLE
Updade backoffice start command with frontend watcher

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       - "CORE_DATABASE_USER=postgres"
       - "CORE_DATABASE_PASSWORD=postgres"
       - "CORE_DATABASE_PORT=5432"
+      - "LOCALDEV=true"
     depends_on:
       - db
   db:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,6 +9,7 @@ services:
     volumes:
       - .:/src
     environment:
+      - "DJANGO_SETTINGS_MODULE=localdev.settings"
       - "DJANGO_CONFIGURATION=Backoffice"
       - "CORE_DATABASE_NAME=postgres"
       - "CORE_DATABASE_HOST=db"

--- a/src/poetry/_general.py
+++ b/src/poetry/_general.py
@@ -9,7 +9,7 @@ from . import _utils as utils
 
 @utils.sub_command_wrapper
 def build_frontend(set_watcher_mode: bool = False) -> None:
-    watcher = "start" if set_watcher_mode else "watch"
+    watcher = "build" if set_watcher_mode else "watch"
     subprocess.run(
         ("npm", "run", watcher),
         cwd=os.path.join(utils.SRC_DIR, "queenbees/interfaces/backoffice/static_src"),


### PR DESCRIPTION
## :question: What is changing?

Frontend watcher is not started automatically from running docker-compose

## :zap: Why this change?

That makes the life easier for localdev

## :sparkles: Change type:

* [ ] Bug fix
* [ ] New feature
* [ ] Refactor
* [X] Quality of life
* [ ] Documentation

## :pencil2: Check list before merging

* [ ] Relevant tests have been added
* [ ] Relevant documentation have been added
